### PR TITLE
CM-S3 Lock Solidity version at 0.8.17

### DIFF
--- a/contracts/Api3PartialAggregatorV2V3Interface.sol
+++ b/contracts/Api3PartialAggregatorV2V3Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity 0.8.17;
 
 import {AggregatorV2V3Interface} from "./vendor/AggregatorV2V3Interface.sol";
 


### PR DESCRIPTION
Locks Solidity version at 0.8.17, the version that we use with the rest of our contracts